### PR TITLE
Заменён домен Telegram-ссылок

### DIFF
--- a/course/module-0/intro-community/article.md
+++ b/course/module-0/intro-community/article.md
@@ -11,12 +11,12 @@ meta:
 
 Коммуникация организована через:
 
--   **<a href="https://t.me/sqlacademyorg/21" target="_blank">чат в Telegram</a>**
+-   **<a href="https://telegram.me/sqlacademyorg/21" target="_blank">чат в Telegram</a>**
 -   **<a href="https://vk.com/sqlacademy" target="_blank">сообщество ВКонтакте</a>**
 
 На странице сообщества мы выкладываем информацию по последним наиболее важным обновлениям, а также много образовательного контента по SQL, реляционным базам данных, и как с помощью них найти работу или получить повышение.
 
-Для общения между участниками есть чат **<a href="https://t.me/sqlacademyorg" target="_blank">в Telegram </a>**.
+Для общения между участниками есть чат **<a href="https://telegram.me/sqlacademyorg" target="_blank">в Telegram </a>**.
 
 ## Решение проблем
 


### PR DESCRIPTION
Ссылки Telegram в статье о сообществе переведены с `t.me` на `telegram.me`, поскольку старый домен недоступен. Пути чата не изменены.

Проверено: `git diff --check`, старый домен в репозитории отсутствует.
